### PR TITLE
Updated to Python 3.9 for Ubuntu 22.04

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -3,13 +3,13 @@ echo "**************************************************"
 echo " Setting up TDD/BDD Final Project Environment"
 echo "**************************************************"
 
-echo "*** Installing Python 3.8 and Virtual Environment"
+echo "*** Installing Python 3.9 and Virtual Environment"
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3.8 python3.8-venv
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3.9 python3.9-venv
 
-echo "*** Making Python 3.8 the default..."
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
+echo "*** Making Python 3.9 the default..."
+sudo update-alternatives --remove-all python3
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 
 echo "*** Checking the Python version..."
 python3 --version


### PR DESCRIPTION
Changed the `bin/setup.sh` script to install Python 3.9 and set it as the default Python 3 for Ubuntu 22.04.